### PR TITLE
updated v3.0.0

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,6 +2,21 @@ set OPENSSL_DIR=%LIBRARY_PREFIX%
 REM Create temp folder
 mkdir tmpbuild_%PY_VER%
 set TEMP=%CD%\tmpbuild_%PY_VER%
+
+REM Fix protos symlinks: tarball symlinks (rust/*/protos -> ../../protos) are
+REM not resolved on Windows, causing protoc to fail with "File not found".
+REM Replace them with real copies of the root protos/ directory.
+REM See: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1492698&view=logs&jobId=535b614b-9e28-51ef-eb67-d0aa83d01d61
+pushd rust
+for /d %%d in (*) do (
+    if exist "%%d\protos" (
+        rmdir /s /q "%%d\protos" 2>nul
+        del /q "%%d\protos" 2>nul
+        xcopy /e /i /q "..\protos" "%%d\protos" >nul
+    )
+)
+popd
+
 REM Bundle all downstream library licenses
 cd python
 cargo-bundle-licenses ^

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pylance" %}
-{% set version = "2.0.1" %}
+{% set version = "3.0.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/lancedb/lance/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 07ef724dff55b1125291f0bfbd0e2f08e453f508fe6ca98d1ad9d34b11dc70ad
+  sha256: a78572c08f7a3320ab67f8ceafbf8a5d08be3687e03e5239b23011af0aacd085
 
 build:
   number: 0
@@ -32,7 +32,7 @@ requirements:
     - python
     - numpy >=1.22
     - pyarrow >=14
-    - lance-namespace >=0.4.5
+    - lance-namespace >=0.5.2
 
 test:
   imports:


### PR DESCRIPTION
## Summary
- Update pylance to v3.0.0
- Bump `lance-namespace` constraint to `>=0.5.2`
- rust_compiler_version stays at 1.92.0 (upstream rust-toolchain = 1.91.0)